### PR TITLE
omit 'sonar.branch.name' if options.branches is false

### DIFF
--- a/packages/nx-sonarqube/src/executors/scan/utils/utils.ts
+++ b/packages/nx-sonarqube/src/executors/scan/utils/utils.ts
@@ -98,31 +98,39 @@ export async function scanner(
   logger.log(`Included sources: ${paths.sources}`);
   if (!options.qualityGate) logger.warn(`Skipping quality gate check`);
 
+  let scannerOptions: { [option: string]: string } = {
+    'sonar.exclusions': options.exclusions,
+    'sonar.javascript.lcov.reportPaths': paths.lcovPaths,
+    'sonar.language': 'ts',
+    'sonar.login': process.env.SONAR_LOGIN,
+    'sonar.organization': options.organization,
+    'sonar.password': process.env.SONAR_PASSWORD,
+    'sonar.projectKey': options.projectKey,
+    'sonar.projectName': options.projectName,
+    'sonar.projectVersion': options.projectVersion,
+    'sonar.qualitygate.timeout': options.qualityGateTimeout,
+    'sonar.qualitygate.wait': String(options.qualityGate),
+    'sonar.scm.provider': 'git',
+    'sonar.sources': paths.sources,
+    'sonar.sourceEncoding': 'UTF-8',
+    'sonar.tests': paths.sources,
+    'sonar.test.inclusions': options.testInclusions,
+    'sonar.typescript.tsconfigPath': 'tsconfig.base.json',
+    'sonar.verbose': String(options.verbose),
+  };
+
+  if (options.branches) {
+    scannerOptions = {
+      'sonar.branch.name': execSync(
+        'git rev-parse --abbrev-ref HEAD'
+      ).toString(),
+      ...scannerOptions,
+    };
+  }
+
   sonarQubeScanner({
     serverUrl: options.hostUrl,
-    options: {
-      'sonar.branch.name': options.branches
-        ? execSync('git rev-parse --abbrev-ref HEAD').toString()
-        : '',
-      'sonar.exclusions': options.exclusions,
-      'sonar.javascript.lcov.reportPaths': paths.lcovPaths,
-      'sonar.language': 'ts',
-      'sonar.login': process.env.SONAR_LOGIN,
-      'sonar.organization': options.organization,
-      'sonar.password': process.env.SONAR_PASSWORD,
-      'sonar.projectKey': options.projectKey,
-      'sonar.projectName': options.projectName,
-      'sonar.projectVersion': options.projectVersion,
-      'sonar.qualitygate.timeout': options.qualityGateTimeout,
-      'sonar.qualitygate.wait': String(options.qualityGate),
-      'sonar.scm.provider': 'git',
-      'sonar.sources': paths.sources,
-      'sonar.sourceEncoding': 'UTF-8',
-      'sonar.tests': paths.sources,
-      'sonar.test.inclusions': options.testInclusions,
-      'sonar.typescript.tsconfigPath': 'tsconfig.base.json',
-      'sonar.verbose': String(options.verbose),
-    },
+    options: scannerOptions,
   });
 }
 


### PR DESCRIPTION
Slight refactor to completely omit `sonar.branch.name` from the options if `options.branches` is false.