### PR TITLE
Replace all underscores of environment variables

### DIFF
--- a/packages/nx-sonarqube/src/executors/scan/executor.spec.ts
+++ b/packages/nx-sonarqube/src/executors/scan/executor.spec.ts
@@ -337,6 +337,7 @@ describe('Scan Executor', () => {
     jest.spyOn(fs, 'readFileSync').mockReturnValue(jestConfig);
     sonarQubeScanner.async.mockResolvedValue(true);
     process.env['SONAR_BRANCH'] = 'main';
+    process.env['SONAR_LOG_LEVEL_EXTENDED'] = 'DEBUG';
     process.env['SONAR_VERBOSE'] = 'true';
 
     const output = getScannerOptions(
@@ -360,6 +361,7 @@ describe('Scan Executor', () => {
     expect(output['sonar.branch']).toBe('main');
     expect(output['sonar.verbose']).toBe('true');
     expect(output['sonar.log.level']).toBe('DEBUG');
+    expect(output['sonar.log.level.extended']).toBe('DEBUG');
     expect(output['sonar.test.inclusions']).toBe('include');
   });
 });

--- a/packages/nx-sonarqube/src/executors/scan/utils/utils.ts
+++ b/packages/nx-sonarqube/src/executors/scan/utils/utils.ts
@@ -39,7 +39,7 @@ class EnvMarshaller implements OptionMarshaller {
       .filter((e) => e.startsWith('SONAR'))
       .reduce((option, env) => {
         let sonarEnv = env.toLowerCase();
-        sonarEnv = sonarEnv.replace('_', '.');
+        sonarEnv = sonarEnv.replace(/_/g, '.');
         option[sonarEnv] = process.env[env];
         return option;
       }, {});


### PR DESCRIPTION
**TLDR**
A `string.replace` will only replace the first hit, using a global regex it replaces all hits.

![image](https://github.com/koliveira15/nx-sonarqube/assets/13710296/e5e2fbb2-368e-452f-a813-6e8e2b0dedba)

**Description**
Hi,
When working with this library and looking at the README I saw that the process environment variables can be used.
In the docs it says  `SONAR_LOG_LEVEL` will be transformed to `sonar.log.level`, right now it seems to be transformed to `sonar.log_level`.
This seems to be due to a string.replace using a string to find the underscore(s) which results in only the first underscore to be replaced