### PR TITLE
Fix projectVersion definition via env variable

### DIFF
--- a/packages/nx-sonarqube/src/executors/scan/executor.spec.ts
+++ b/packages/nx-sonarqube/src/executors/scan/executor.spec.ts
@@ -226,6 +226,7 @@ describe('Scan Executor', () => {
   });
 
   afterEach(() => {
+    delete process.env['SONAR_PROJECTVERSION'];
     jest.clearAllMocks();
   });
 
@@ -490,6 +491,44 @@ describe('Scan Executor', () => {
     );
 
     expect(output['sonar.projectVersion']).toBe(packageVersion);
+  });
+  it('should return env variable version', async () => {
+    (
+      readJsonFile as jest.MockedFunction<typeof readJsonFile>
+    ).mockImplementation(() => {
+      return {};
+    });
+    sonarQubeScanner.async.mockResolvedValue(true);
+    process.env['SONAR_BRANCH'] = 'main';
+    process.env['SONAR_LOG_LEVEL_EXTENDED'] = 'DEBUG';
+    process.env['SONAR_VERBOSE'] = 'true';
+    process.env['SONAR_PROJECTVERSION'] = '1.1.1';
+
+    const output = getScannerOptions(
+      context,
+      {
+        hostUrl: 'url',
+        verbose: false,
+        projectKey: 'key',
+        qualityGate: true,
+        organization: 'org',
+        testInclusions: 'include',
+        extra: {
+          'sonar.test.inclusions': 'dontInclude',
+          'sonar.log.level': 'DEBUG',
+        },
+      },
+      'src/',
+      'coverage/apps',
+      ''
+    );
+
+    expect(output['sonar.branch']).toBe('main');
+    expect(output['sonar.verbose']).toBe('true');
+    expect(output['sonar.log.level']).toBe('DEBUG');
+    expect(output['sonar.log.level.extended']).toBe('DEBUG');
+    expect(output['sonar.test.inclusions']).toBe('include');
+    expect(output['sonar.projectVersion']).toBe('1.1.1');
   });
   it('should return no version', async () => {
     (

--- a/packages/nx-sonarqube/src/executors/scan/utils/utils.ts
+++ b/packages/nx-sonarqube/src/executors/scan/utils/utils.ts
@@ -35,12 +35,17 @@ class ExtraMarshaller implements OptionMarshaller {
   }
 }
 class EnvMarshaller implements OptionMarshaller {
+  private readonly normalizedOptionsName = {
+    ['sonar.projectversion']: 'sonar.projectVersion',
+  }
+
   Options(): { [p: string]: string } {
     return Object.keys(process.env)
       .filter((e) => e.startsWith('SONAR'))
       .reduce((option, env) => {
         let sonarEnv = env.toLowerCase();
         sonarEnv = sonarEnv.replace(/_/g, '.');
+        sonarEnv = this.normalizedOptionsName[sonarEnv] || sonarEnv;
         option[sonarEnv] = process.env[env];
         return option;
       }, {});


### PR DESCRIPTION
According to [documentation](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/analysis-parameters/), sonar properties are case-sensitive.
This is an issue when we try to use env variables to set properties like sonar.projectVersion.