### PR TITLE
Support detecting inferred tasks test task configurations from Project Crystal

### DIFF
--- a/e2e/nx-sonarqube-e2e/project.json
+++ b/e2e/nx-sonarqube-e2e/project.json
@@ -13,6 +13,9 @@
       },
       "dependsOn": ["nx-sonarqube:build"]
     },
+    "lint": {
+      "executor": "nx:noop"
+    },
     "sonar": {
       "executor": "@koliveira15/nx-sonarqube:scan",
       "options": {

--- a/e2e/nx-sonarqube-e2e/project.json
+++ b/e2e/nx-sonarqube-e2e/project.json
@@ -16,6 +16,9 @@
     "lint": {
       "executor": "nx:noop"
     },
+    "test": {
+      "executor": "nx:noop"
+    },
     "sonar": {
       "executor": "@koliveira15/nx-sonarqube:scan",
       "options": {

--- a/nx.json
+++ b/nx.json
@@ -30,6 +30,20 @@
       "cache": true
     }
   },
+  "plugins": [
+    {
+      "plugin": "@nx/jest/plugin",
+      "options": {
+        "targetName": "test"
+      }
+    },
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      }
+    }
+  ],
   "workspaceLayout": {
     "appsDir": "e2e",
     "libsDir": "packages"

--- a/packages/nx-sonarqube/project.json
+++ b/packages/nx-sonarqube/project.json
@@ -36,10 +36,6 @@
         ]
       }
     },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
     "test": {
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/packages/nx-sonarqube"],


### PR DESCRIPTION
Previous logic relied on the explicit project.json `test` executor options to derive configuration paths. Since Nx 18 & Project Crystal, those configurations could potentially not exist and are inferred by Nx.