### PR TITLE
#66 - feat: allow to skip all deps

### DIFF
--- a/packages/nx-sonarqube/src/executors/scan/schema.d.ts
+++ b/packages/nx-sonarqube/src/executors/scan/schema.d.ts
@@ -8,7 +8,9 @@ export interface ScanExecutorSchema {
   projectVersion?: string;
   qualityGate?: boolean;
   qualityGateTimeout?: string;
+  // replace next lines with something like skipDeps?: 'all' | 'implicit' | 'none'; defaulting to 'none'
   skipImplicitDeps?: boolean;
+  skipAllDeps?: boolean;
   testInclusions?: string;
   tsConfig?: string;
   verbose?: boolean;

--- a/packages/nx-sonarqube/src/executors/scan/schema.json
+++ b/packages/nx-sonarqube/src/executors/scan/schema.json
@@ -51,6 +51,11 @@
       "type": "boolean",
       "default": false
     },
+    "skipAllDeps": {
+      "description": "Skips any dependencies to the project graph analysis",
+      "type": "boolean",
+      "default": false
+    },
     "testInclusions": {
       "description": "Comma-delimited list of test file path patterns to be included in analysis. When set, only test files matching the paths set here will be included in analysis",
       "type": "string",

--- a/packages/nx-sonarqube/src/executors/scan/utils/utils.ts
+++ b/packages/nx-sonarqube/src/executors/scan/utils/utils.ts
@@ -92,7 +92,9 @@ export async function determinePaths(
 ): Promise<{ lcovPaths: string; sources: string }> {
   const sources: string[] = [];
   const lcovPaths: string[] = [];
-  const deps = await getDependentPackagesForProject(context.projectName);
+  const deps = options.skipAllDeps ?
+    await getDependentPackagesForProject(context.projectName)
+    : {workspaceLibraries: []};
   const projectConfiguration = context.projectsConfigurations.projects[context.projectName];
   deps.workspaceLibraries.push({
     name: context.projectName,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Configuration related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] @koliveira15/nx-sonarqube
- [ ] docs-site

## What is the current behavior?

For now, we can only ignore implicit dependencies. While auditing many repositories, it pushes the  app sources and its dependencies that may result in duplicate reports.

Closes #66 

## What is the new behavior?

This PR allows us to ignore all project dependencies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I made it simple but I think a better way to implement this would be to use an enum like this : 

```
skipDeps?: 'none' | 'implicit' | 'all'
```

Also, as the getDependentPackagesForProject function is internal, without modifying a bunch of code, I couldn't test the branch properly