### PR TITLE
feat: recover coverage from multiple jest runs on the same app/package

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "nrwl.angular-console",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "firsttris.vscode-jest-runner"

--- a/packages/nx-sonarqube/src/executors/scan/schema.d.ts
+++ b/packages/nx-sonarqube/src/executors/scan/schema.d.ts
@@ -13,4 +13,5 @@ export interface ScanExecutorSchema {
   tsConfig?: string;
   verbose?: boolean;
   extra?: { [option: string]: string };
+  jestConfigNames?: string | string[];
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Configuration related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] @koliveira15/nx-sonarqube
- [ ] docs-site

## What is the current behavior?

Currently, coverage directory paths are added only once per package. And for the plugin to find the file automatically, it must be written as `jest.config.ts` exactly.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Allow recovering coverage reports for multiple Jest runs in the same app or package.
Allow specifying a different JEST config file name to search.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
